### PR TITLE
fix: feature detection for Google Chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,14 @@ var BIND_STATE_BOUND = 2
 // Track open sockets to route incoming data (via onReceive) to the right handlers.
 var sockets = {}
 
-if (typeof chrome !== 'undefined') {
+// Thorough check for Chrome App since both Edge and Chrome implement dummy chrome object
+if (
+  typeof chrome === 'object' &&
+  typeof chrome.runtime === 'object' &&
+  typeof chrome.runtime.id === 'string' &&
+  typeof chrome.sockets === 'object' &&
+  typeof chrome.sockets.udp === 'object'
+) {
   chrome.sockets.udp.onReceive.addListener(onReceive)
   chrome.sockets.udp.onReceiveError.addListener(onReceiveError)
 } else {


### PR DESCRIPTION
> This is the same fix as https://github.com/feross/chrome-net/pull/36

## What?

This PR adds explicit check if `chrome.sockets.udp` exist before registering related listeners. 

## Why?

`chrome-dgram` did not check if `chrome.sockets.udp` APIs actually exist, which caused problems in browser extensions, making it difficult to maintain a single codebase and do feature-detection at runtime (namely, Google Chrome without `chrome.sockets.udp` vs Brave with).  

Refs. https://github.com/feross/chrome-net/pull/36, https://github.com/ipfs-shipyard/ipfs-companion/issues/664 https://github.com/ipfs-shipyard/ipfs-companion/issues/716

