### PR TITLE
fix: remove console.error on init in regular browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,6 @@ if (
 ) {
   chrome.sockets.udp.onReceive.addListener(onReceive)
   chrome.sockets.udp.onReceiveError.addListener(onReceiveError)
-} else {
-  console.error('Undefined chrome ref, could not register on-receive listener')
 }
 
 function onReceive (info) {


### PR DESCRIPTION
This PR removes unnecessary `console.error` during the init.

### Motivation 

We introduced support for feature detection of Google Chrome in #16.
Unfortunately, if  sockets API is missing (eg. browser extension loads in regular browser – https://github.com/ipfs-shipyard/ipfs-companion/issues/716), console starts with irrelevant error: 

![err-2019-10-04--21-58-48](https://user-images.githubusercontent.com/157609/66236687-71ab3d80-e6f3-11e9-8215-b7ede6b10677.png)

Removing the error aligns `chrome-dgram` with existing behavior of `chrome-net`, which does not print error to the console:

- https://github.com/feross/chrome-net/blob/v3.3.3/index.js#L26-L38
