### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,7 +408,7 @@ Socket.prototype.setMulticastTTL = function (ttl, callback) {
   } else {
     self._bindTasks.push({
       fn: setMulticastTTL,
-      callback: callback
+      callback
     })
   }
 
@@ -436,7 +436,7 @@ Socket.prototype.setMulticastLoopback = function (flag, callback) {
   } else {
     self._bindTasks.push({
       fn: setMulticastLoopback,
-      callback: callback
+      callback
     })
   }
 


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This has been supported since Chrome 43, released in 2015